### PR TITLE
Remove redundant needs from prod deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,8 +168,6 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
     needs:
       - config
-      - unit-tests
-      - integration-tests
     uses: ./.github/workflows/deploy.yml
     with:
       environment: prod


### PR DESCRIPTION
Now that the `unit-tests` and `integration-tests` jobs no longer run when creating a release, we must remove them from the `needs` list for the `deploy-prod` job, otherwise deployment will never happen.

(Note: we have prevented `unit-tests` and `integration-tests` from running on release because it is redundant to do so. They must have already run and passed in order for the code to have landed on the `main` branch to begin with.)