### PR TITLE
fix: print file count per granule

### DIFF
--- a/src/hls_lpdaac_reconciliation/response/__init__.py
+++ b/src/hls_lpdaac_reconciliation/response/__init__.py
@@ -1,4 +1,5 @@
 import re
+from collections import defaultdict
 from typing import Literal, Mapping, Sequence
 
 
@@ -81,27 +82,44 @@ def group_granule_ids(
     report sequence, and the separator is a sequence of 3 underscores (`_`), as per
     Cumulus convention.
 
-    Returns all of the unique `<GRANULE_ID>` values (as a sorted tuple), grouped by
-    unique collection ID, which is a tuple of the form `("<SHORT_NAME>", "<VERSION>")`:
+    Returns all of the unique `<GRANULE_ID>` values and file counts (as a sorted tuple),
+    grouped by unique collection ID, which is a tuple of the form
+    `("<SHORT_NAME>", "<VERSION>")`:
 
         {
             ("<SHORT_NAME>", "<VERSION>"): ("<GRANULE_ID>", ...),
             ...
         }
     """
+    grouped_granule_ids = {}
+    for collection_report in report:
+        for collection_id, collection_info in collection_report.items():
+            decoded_collection_id = decode_collection_id(collection_id)
 
-    return {
-        decode_collection_id(collection_id): tuple(
-            sorted(
-                {
-                    file_info["granuleId"]
-                    for file_info in collection_info["report"].values()
-                }
+            # count files per granule id
+            counts_by_granule_id = defaultdict(lambda: 0)
+            for filename, info in collection_info["report"].items():
+                counts_by_granule_id[info["granuleId"]] += 1
+
+            # sort by granule ID before accumulating for this collection
+            counts_by_granule_id = dict(
+                sorted(
+                    counts_by_granule_id.items(), key=lambda kv: kv[0]
+                )
             )
-        )
-        for collection_report in report
-        for collection_id, collection_info in collection_report.items()
-    }
+
+            # log file count by granule ID
+            for granule_id, count in counts_by_granule_id.items():
+                print(
+                    f"{granule_id} granule ({count} files) differences "
+                    f"in {decoded_collection_id}"
+                )
+
+            grouped_granule_ids[decoded_collection_id] = tuple(
+                sorted(counts_by_granule_id)
+            )
+
+    return grouped_granule_ids
 
 
 def notification_trigger_key(granule_id: str) -> str:

--- a/src/hls_lpdaac_reconciliation/response/__init__.py
+++ b/src/hls_lpdaac_reconciliation/response/__init__.py
@@ -50,7 +50,7 @@ def group_granule_ids(
             ],
         ]
     ]
-) -> Mapping[tuple[str, str], Sequence[str]]:
+) -> Mapping[str, tuple[int, Sequence[str]]]:
     """Group unique granule IDs by collection from a report.
 
     A report must be structured like so (keys within the structure other than those
@@ -81,23 +81,25 @@ def group_granule_ids(
     report sequence, and the separator is a sequence of 3 underscores (`_`), as per
     Cumulus convention.
 
-    Returns all of the unique `<GRANULE_ID>` values (as a sorted tuple), grouped by
-    unique collection ID, which is a tuple of the form `("<SHORT_NAME>", "<VERSION>")`:
+    Returns the total count of files and all of the unique `<GRANULE_ID>` values
+    (as a sorted tuple), grouped by unique collection ID:
 
         {
-            ("<SHORT_NAME>", "<VERSION>"): ("<GRANULE_ID>", ...),
+            "<SHORT_NAME>___<VERSION>": (<FILE COUNT>, ("<GRANULE_ID>", ...)),
             ...
         }
     """
-
     return {
-        decode_collection_id(collection_id): tuple(
-            sorted(
-                {
-                    file_info["granuleId"]
-                    for file_info in collection_info["report"].values()
-                }
-            )
+        collection_id: (
+            len(collection_info["report"]),
+            tuple(
+                sorted(
+                    {
+                        file_info["granuleId"]
+                        for file_info in collection_info["report"].values()
+                    }
+                )
+            ),
         )
         for collection_report in report
         for collection_id, collection_info in collection_report.items()

--- a/src/hls_lpdaac_reconciliation/response/index.py
+++ b/src/hls_lpdaac_reconciliation/response/index.py
@@ -80,7 +80,7 @@ def handler(
 
     if subject and "Ok" in subject:
         # When the subject contains (ends with) "Ok", the message itself
-        # indicates that there are no discrepancies, so there's nothing to do.
+        # indicates that there are no discrepencies, so there's nothing to do.
         # Example: "[External] Rec-Report HLS lp-prod HLS_reconcile_2024240_2.0.rpt Ok"
         return {}
 

--- a/src/hls_lpdaac_reconciliation/response/index.py
+++ b/src/hls_lpdaac_reconciliation/response/index.py
@@ -80,7 +80,7 @@ def handler(
 
     if subject and "Ok" in subject:
         # When the subject contains (ends with) "Ok", the message itself
-        # indicates that there are no discrepencies, so there's nothing to do.
+        # indicates that there are no discrepancies, so there's nothing to do.
         # Example: "[External] Rec-Report HLS lp-prod HLS_reconcile_2024240_2.0.rpt Ok"
         return {}
 

--- a/tests/unit/test_response.txt
+++ b/tests/unit/test_response.txt
@@ -43,15 +43,15 @@ Test group_granule_ids:
     ...             "sent": 12345,
     ...             "failed": 123,
     ...             "report": {
-    ...                 "B01.tif": {
+    ...                 "HLS.L30.ABC.v2.0.B01.tif": {
     ...                     "granuleId": "HLS.L30.ABC.v2.0",
     ...                     "status": "failed"
     ...                 },
-    ...                 "B02.tif": {
+    ...                 "HLS.L30.ABC.v2.0.B02.tif": {
     ...                     "granuleId": "HLS.L30.ABC.v2.0",
     ...                     "status": "failed"
     ...                 },
-    ...                 "B01.tif": {
+    ...                 "HLS.L30.XYZ.v2.0.B01.tif": {
     ...                     "granuleId": "HLS.L30.XYZ.v2.0",
     ...                     "status": "failed"
     ...                 },
@@ -61,11 +61,11 @@ Test group_granule_ids:
     ...             "sent": 12345,
     ...             "failed": 123,
     ...             "report": {
-    ...                 "B01.tif": {
+    ...                 "HLS.S30.ABC.v2.0.B01.tif": {
     ...                     "granuleId": "HLS.S30.ABC.v2.0",
     ...                     "status": "failed"
     ...                 },
-    ...                 "B02.tif": {
+    ...                 "HLS.S30.ABC.v2.0.B02.tif": {
     ...                     "granuleId": "HLS.S30.ABC.v2.0",
     ...                     "status": "failed"
     ...                 }
@@ -75,6 +75,6 @@ Test group_granule_ids:
     ...     }
     ... ]
     >>> group_granule_ids(report)
-    {('HLSL30', '2.0'): ('HLS.L30.ABC.v2.0', 'HLS.L30.XYZ.v2.0'),
-     ('HLSS30', '2.0'): ('HLS.S30.ABC.v2.0',),
-     ('HLSS30_VI', '2.0'): ()}
+    {'HLSL30___2.0': (3, ('HLS.L30.ABC.v2.0', 'HLS.L30.XYZ.v2.0')),
+     'HLSS30___2.0': (2, ('HLS.S30.ABC.v2.0',)),
+     'HLSS30_VI___2.0': (0, ())}

--- a/tests/unit/test_response.txt
+++ b/tests/unit/test_response.txt
@@ -75,9 +75,6 @@ Test group_granule_ids:
     ...     }
     ... ]
     >>> group_granule_ids(report)
-    HLS.L30.ABC.v2.0 granule (1 files) differences in ('HLSL30', '2.0')
-    HLS.L30.XYZ.v2.0 granule (1 files) differences in ('HLSL30', '2.0')
-    HLS.S30.ABC.v2.0 granule (2 files) differences in ('HLSS30', '2.0')
     {('HLSL30', '2.0'): ('HLS.L30.ABC.v2.0', 'HLS.L30.XYZ.v2.0'),
      ('HLSS30', '2.0'): ('HLS.S30.ABC.v2.0',),
      ('HLSS30_VI', '2.0'): ()}

--- a/tests/unit/test_response.txt
+++ b/tests/unit/test_response.txt
@@ -75,6 +75,9 @@ Test group_granule_ids:
     ...     }
     ... ]
     >>> group_granule_ids(report)
+    HLS.L30.ABC.v2.0 granule (1 files) differences in ('HLSL30', '2.0')
+    HLS.L30.XYZ.v2.0 granule (1 files) differences in ('HLSL30', '2.0')
+    HLS.S30.ABC.v2.0 granule (2 files) differences in ('HLSS30', '2.0')
     {('HLSL30', '2.0'): ('HLS.L30.ABC.v2.0', 'HLS.L30.XYZ.v2.0'),
      ('HLSS30', '2.0'): ('HLS.S30.ABC.v2.0',),
      ('HLSS30_VI', '2.0'): ()}


### PR DESCRIPTION
## Background

This PR changes the logging for our reconciliation process to log the number of files affected per granule ID and collection. The intention here is to provide more information about the individual granules ("bottom up") that will match the "top down" information provided by the report totals.

For example the reconciliation report from `lp-prod-reconciliation/reports/HLS_reconcile_2024305_2.0.json` indicated that 42 files had failed. Previously we only logged information about 2 granules, which might've been confusing because 2 doesn't add up to 42. With this PR instead we see,

```
>>> group_granule_ids(report)

{('HLSL30', '2.0'): (0, ()),
 ('HLSS30', '2.0'): (2, ('HLS.S30.T60HTG.2024303T222539.v2.0',
  'HLS.S30.T60HUB.2024303T222539.v2.0'))}
```

The 21 files for each of the 2 granules totals to 42, which should help us better interpret what went wrong.

This PR should close, https://github.com/NASA-IMPACT/hls-lpdaac-reconciliation/issues/6

## How I did it

* Update `group_granule_ids` to also return the number of files from the granules that are grouped by collection ID
* Lift the print statement from `process_collection` into `process_report` since we still have the file counts at that scope. This also involved unrolling a dict comprehension into a for-loop
* Remove a "parse + unparse" of the Collection ID since originally the code had reconstructed the Cumulus collection ID inside of `process_report`
* I updated the test data in `test_response.txt` because the example used the same filename for two different granules, causing 1 of the entries to clobber another. The filenames in practice have the granule ID information prepended

## How you can test it

I updated the unit test expectations for the return signature change of `get_granule_ids`,

```
pytest tests/unit/test_response.txt
```