### PR TITLE
Fix VI trigger file identification & memory size

### DIFF
--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -86,7 +86,7 @@ class HlsLpdaacReconciliationStack(Stack):
             code=lambda_.Code.from_asset("src", exclude=["**/*.egg-info"]),
             handler="hls_lpdaac_reconciliation/response/index.handler",
             runtime=lambda_.Runtime.PYTHON_3_12,
-            memory_size=128,
+            memory_size=4096,
             timeout=Duration.minutes(15),
             environment={
                 "HLS_FORWARD_BUCKET": hls_forward_bucket,

--- a/src/hls_lpdaac_reconciliation/response/__init__.py
+++ b/src/hls_lpdaac_reconciliation/response/__init__.py
@@ -110,7 +110,11 @@ def notification_trigger_key(granule_id: str) -> str:
     """Returns the key for the S3 notification trigger object for a granule."""
     # Example: HLS.S30.T15XWH.2024237T194859.v2.0
     # 'HLS', 'S30', 'T15XWH', '2024237T194859', ['v2', '0']
-    _hls, instrument, _tile_id, datetime, *_version = granule_id.split(".")
+    prefix, instrument, _tile_id, datetime, *_version = granule_id.split(".")
+    # Prefix is either HLS or HLS-VI
+    _hls, *vi = prefix.split("-")
     date, _time = datetime.split("T")
 
-    return f"{instrument}/data/{date}/{granule_id}/{granule_id}.json"
+    return (
+        f"{instrument}{'_VI' if vi else ''}/data/{date}/{granule_id}/{granule_id}.json"
+    )

--- a/tests/unit/test_response.txt
+++ b/tests/unit/test_response.txt
@@ -33,6 +33,8 @@ Test notification_trigger_key:
     >>> from hls_lpdaac_reconciliation.response import notification_trigger_key
     >>> notification_trigger_key("HLS.S30.T15XWH.2024237T194859.v2.0")
     'S30/data/2024237/HLS.S30.T15XWH.2024237T194859.v2.0/HLS.S30.T15XWH.2024237T194859.v2.0.json'
+    >>> notification_trigger_key("HLS-VI.L30.T50WPA.2025083T034714.v2.0")
+    'L30_VI/data/2025083/HLS-VI.L30.T50WPA.2025083T034714.v2.0/HLS-VI.L30.T50WPA.2025083T034714.v2.0.json'
 
 Test group_granule_ids:
 


### PR DESCRIPTION
Correctly constructs path to a VI granule's "trigger" file so that we can "touch" the file to re-trigger LP DAAC notification.

Also, bumps Lambda memory size from 128MB to 4096MB to accommodate large "diff" files from LP DAAC.

Fixes #10 
Fixes #11 