### PR TITLE
Use multithreading in "diff" response handler to improve throughput

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -10,6 +10,8 @@ inputs:
   aws_role_session_name:
     description: AWS role session name
     required: true
+  stack_name:
+    description: Name of the stack to deploy (intended only for uniquely naming integration test stacks)
   vars_json:
     description: Environment variables as a JSON object
   secrets_json:
@@ -67,5 +69,7 @@ runs:
 
     - name: Deploy stack
       shell: bash
+      env:
+        HLS_LPDAAC_STACK: ${{ inputs.stack_name || env.HLS_LPDAAC_STACK }}
       run: |
         ${{ inputs.command }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,12 +70,17 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
+      - name: Get commit short SHA
+        run: |
+          echo "GITHUB_SHORT_SHA=$(echo ${{ github.sha }} | cut -c 1-7)" >> $GITHUB_ENV
+
       - name: Deploy integration tests stack
         uses: ./.github/actions/deploy
         with:
           aws_region: "${{ vars.AWS_DEFAULT_REGION }}"
           aws_role_to_assume_arn: "${{ vars.AWS_ROLE_TO_ASSUME_ARN }}"
           aws_role_session_name: "${{ github.actor }}"
+          stack_name: "test-${{ env.GITHUB_SHORT_SHA }}"
           vars_json: "${{ toJson(vars) }}"
           secrets_json: "${{ toJson(secrets) }}"
           command: make deploy-it
@@ -87,7 +92,7 @@ jobs:
         if: "${{ !cancelled() }}"
         run: make destroy-it
 
-  deploy:
+  deploy-prod:
     # Deploy to Prod only on publishing a release (tag)
     if: github.event_name == 'release'
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL=/usr/bin/env bash
 UV=uv run $(UV_OPTS)
 UV_OPTS?=--no-progress
 
-.PHONY: help integration-tests unit-tests
+.PHONY: help integration-tests unit-tests update-npm update-cdk
 .DEFAULT_GOAL := help
 
 help: Makefile
@@ -19,7 +19,15 @@ help: Makefile
 .venv/bin/npm:
 	$(UV) nodeenv --node lts --python-virtualenv
 
+## update-npm: Install the current LTS version of npm
+update-npm:
+	$(UV) nodeenv --node lts --python-virtualenv
+
 .venv/bin/cdk: .venv/bin/npm
+	$(UV) npm install --location global "aws-cdk@latest"
+
+## update-cdk: Install latest version of the AWS CDK CLI
+update-cdk:
 	$(UV) npm install --location global "aws-cdk@latest"
 
 ## unit-tests: Run unit tests

--- a/cdk.context.json
+++ b/cdk.context.json
@@ -1,0 +1,5 @@
+{
+  "acknowledged-issue-numbers": [
+    34892
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,8 @@ addopts = [
 ]
 doctest_optionflags = ["ELLIPSIS", "NORMALIZE_WHITESPACE", "NUMBER"]
 testpaths = ["tests/unit"]
+filterwarnings =  [
+    # See https://docs.python.org/3/library/warnings.html#the-warnings-filter
+    # action:[message regex]:[category]:[module]:[lineno]
+    'ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning:botocore.*'
+]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
+
 import json
+from collections.abc import Sequence
 from pathlib import Path
+from typing import Iterator
 
 import boto3
 import pytest
@@ -45,3 +48,60 @@ def cdk_outputs() -> dict[str, str]:
         ),
         {},
     )
+
+
+@pytest.fixture(scope="session")
+def hls_bucket(cdk_outputs: dict[str, str]) -> str:
+    return cdk_outputs["HlsForwardBucketName"]
+
+
+@pytest.fixture(scope="session")
+def lpdaac_bucket(cdk_outputs: dict[str, str]) -> str:
+    return cdk_outputs["LpdaacReconciliationReportsBucketName"]
+
+
+@pytest.fixture(scope="session")
+def response_topic_arn(cdk_outputs: dict[str, str]) -> str:
+    return cdk_outputs["LpdaacResponseTopicArn"]
+
+
+@pytest.fixture(scope="session")
+def report_path() -> Path:
+    return Path("tests") / "fixtures" / "HLS_reconcile_2024239_2.0.json"
+
+
+@pytest.fixture
+def trigger_keys(
+    s3: S3Client, hls_bucket: str, report_path: Path
+) -> Iterator[Sequence[str]]:
+    from hls_lpdaac_reconciliation.response import (
+        group_granule_ids,
+        notification_trigger_key,
+    )
+
+    keys = [
+        notification_trigger_key(granule_id)
+        for (_nfiles, granule_ids) in group_granule_ids(
+            json.loads(report_path.read_text())
+        ).values()
+        for granule_id in granule_ids
+    ]
+
+    for key in keys:
+        # Write trigger file (contents don't matter; we just need a file to "touch")
+        s3.put_object(Bucket=hls_bucket, Key=key, Body=b"{}")
+
+    yield keys
+
+    for key in keys:
+        s3.delete_object(Bucket=hls_bucket, Key=key)
+
+
+@pytest.fixture
+def hls_inventory_reports_bucket(cdk_outputs: dict[str, str]) -> str:
+    return cdk_outputs["HlsInventoryReportsBucketName"]
+
+
+@pytest.fixture
+def lpdaac_request_queue_url(cdk_outputs: dict[str, str]) -> str:
+    return cdk_outputs["LpdaacRequestQueueUrl"]

--- a/tests/integration/test_request.py
+++ b/tests/integration/test_request.py
@@ -1,33 +1,38 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
 
 from mypy_boto3_s3 import S3Client
 from mypy_boto3_sqs import SQSClient
 
 
 def test_request_handler(
-    cdk_outputs: Mapping[str, str], s3: S3Client, sqs: SQSClient
+    s3: S3Client,
+    sqs: SQSClient,
+    hls_inventory_reports_bucket: str,
+    lpdaac_request_queue_url: str,
 ) -> None:
-    bucket = cdk_outputs["HlsInventoryReportsBucketName"]
     key = "inventory.rpt"
 
     # Write S3 inventory report file (contents don't matter)
-    s3.put_object(Bucket=bucket, Key=key, Body=bytes())
+    s3.put_object(Bucket=hls_inventory_reports_bucket, Key=key, Body=bytes())
 
     # Read message from SQS queue that is subscribed to SNS topic to which the handler
     # should have published a message indicating the location of the inventory report.
-    queue_url = cdk_outputs["LpdaacRequestQueueUrl"]
     # Set MaxNumberOfMessages > 1 to test that only 1 message was published
     result = sqs.receive_message(
-        QueueUrl=queue_url, MaxNumberOfMessages=2, WaitTimeSeconds=20
+        QueueUrl=lpdaac_request_queue_url, MaxNumberOfMessages=2, WaitTimeSeconds=20
     )
     messages = result.get("Messages", [])
+
+    for message in messages:
+        receipt = message["ReceiptHandle"]  # pyright: ignore[reportTypedDictNotRequiredAccess]
+
+        sqs.delete_message(QueueUrl=lpdaac_request_queue_url, ReceiptHandle=receipt)
 
     assert len(messages) == 1
 
     body = json.loads(messages[0].get("Body") or "{}")
     message = json.loads(body.get("Message"))
 
-    assert message == {"report": {"uri": f"s3://{bucket}/{key}"}}
+    assert message == {"report": {"uri": f"s3://{hls_inventory_reports_bucket}/{key}"}}


### PR DESCRIPTION
For LP DAAC reconciliation "diff" reports with a long list of diffs (~10K granules/~200K files in total, across all collections within the report), the Lambda handler exceeds its 15-minute time limit.

This adds multithreading to the handler in an attempt to easily support a report with >10K granules without having to resort to a more complex solution (such as ECS), particularly because our long-term solution for reconciliation eliminates this problem entirely.

Until we deploy this and receive a large diff report, it will be difficult to benchmark the change, but given the number of workers (7) used for the current lambda instance size, a perfectly linear speedup should allow us to handle up to ~70K granules, but even a much more conservative estimate of ~50K granules would, I believe, handle the maximum size of a daily diff report.