### PR TITLE
fix: Glue table format includes HH-mm

### DIFF
--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -189,10 +189,10 @@ class HlsLpdaacReconciliationStack(Stack):
                 parameters={
                     "projection.enabled": "true",
                     "projection.dt.type": "date",
-                    "projection.dt.format": "yyyy-MM-dd",
-                    "projection.dt.range": "2025-06-03,NOW",
+                    "projection.dt.format": "yyyy-MM-dd-HH-mm",
+                    "projection.dt.range": "2025-06-03-00-00,NOW",
                     "projection.dt.interval": "1",
-                    "projection.dt.interval.unit": "DAYS",
+                    "projection.dt.interval.unit": "HOURS",
                 },
                 partition_keys=[
                     CfnTable.ColumnProperty(name="dt", type="string"),

--- a/tests/integration/test_generate_report.py
+++ b/tests/integration/test_generate_report.py
@@ -74,7 +74,7 @@ def df_fake_inventory(
       - s3://{inventory-bucket}/{data-bucket}/{inventory-id}/{report-date}/manifest.json
       - s3://{inventory-bucket}/{data-bucket}/{inventory-id}/{report-date}/manifest.checksum
     """
-    report_date = "2025-06-03"
+    report_date = "2025-06-03-01-00"
     inventory_parquet_key = (
         f"{hls_bucket}/{hls_inventory_reports_id}/data/{uuid4()}.parquet"
     )


### PR DESCRIPTION
## Description

This PR fixes our Glue table definition for S3 inventories by including the hours and minutes in `dt=YYYY-MM-DD-HH-mm`.

This had worked previously in our integration tests because the faked inventory data was also incorrect!