### PR TITLE
Split combined report into one report per product

### DIFF
--- a/src/hls_lpdaac_reconciliation/generate_report/index.py
+++ b/src/hls_lpdaac_reconciliation/generate_report/index.py
@@ -113,8 +113,8 @@ def generate_report(
     athena: AthenaClient,
     s3: S3Client,
     table: str,
-    start_date: dt.datetime,
-    end_date: dt.datetime,
+    start_date: dt.date,
+    end_date: dt.date,
     report_output_location: str,
     query_output_prefix: str,
     catalog: str = "AwsDataCatalog",
@@ -235,7 +235,7 @@ def handler(event: dict[str, Any], _context: object) -> None:
         dt.datetime.fromisoformat(report_start_date_str)
         if (report_start_date_str := event.get("report_start_date"))
         else dt.datetime.now() - dt.timedelta(days=2)
-    )
+    ).date()
     report_end_date = report_start_date + dt.timedelta(days=1)
     inventory_table_name = os.environ["INVENTORY_TABLE_NAME"]
     query_output_prefix = os.environ["QUERY_OUTPUT_PREFIX"]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -71,7 +71,7 @@ def report_path() -> Path:
     return Path("tests") / "fixtures" / "HLS_reconcile_2024239_2.0.json"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def trigger_keys(
     s3: S3Client, hls_bucket: str, report_path: Path
 ) -> Iterator[Sequence[str]]:
@@ -98,7 +98,7 @@ def trigger_keys(
         s3.delete_object(Bucket=hls_bucket, Key=key)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def hls_inventory_reports_bucket(
     s3: S3Client,
     cdk_outputs: dict[str, str],
@@ -112,11 +112,11 @@ def hls_inventory_reports_bucket(
             s3.delete_object(Bucket=bucket, Key=obj["Key"])
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def hls_inventory_reports_id(cdk_outputs: dict[str, str]) -> str:
     return cdk_outputs["HlsInventoryReportId"]
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def lpdaac_request_queue_url(cdk_outputs: dict[str, str]) -> str:
     return cdk_outputs["LpdaacRequestQueueUrl"]


### PR DESCRIPTION
Split daily inventory report file (`.rpt`) generated for LP DAAC, which combines files across all products, into 1 report per product (L30, L30_VI, S30, S30_VI). This not only reduces processing burden on LP DAAC, but also on our end because this also leads to LP DAAC sending individual "diff" files in response, 1 per product.