### PR TITLE
Add GH workflow for manually generating reports

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -1,0 +1,82 @@
+name: Generate Inventory Report
+
+on:
+  workflow_dispatch:
+    inputs:
+      last-modified-date:
+        description: >
+          Last modified date of inventory objects to select, either formated as
+          YYYY-MM-DD (e.g., 2025-06-10) or YYYYDDD (e.g., 2025161, equivalent to
+          2025-06-10), where DDD is day of year.  (Default: 2 days ago)
+        required: false
+        type: string
+      products:
+        description: >
+          Comma-separated list of products to produce reports for.  (Default:
+          L30, L30_VI, S30, S30_VI)
+        required: false
+        type: string
+      lambda-function-name:
+        description: Name or ARN of the report-generator Lambda function
+        required: false
+        type: string
+        # TODO Find reliable means of looking this up in a job step
+        default: hls-lpdaac-reconciliation-InventoryReportHandler89-HlYwwIOfV3yw
+      dry-run:
+        description: >
+          If true, perform a "dry run" invocation of the report generator Lambda
+          function.
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  id-token: write # required for requesting the JWT
+  contents: read # required for actions/checkout
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  generate-reports:
+    runs-on: ubuntu-latest
+    environment: prod
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: "${{ vars.AWS_DEFAULT_REGION }}"
+          role-to-assume: "${{ vars.AWS_ROLE_TO_ASSUME_ARN }}"
+          role-session-name: "${{ github.actor }}"
+
+      - name: Construct Lambda function payload
+        shell: python
+        run: |
+          from datetime import datetime as dt
+          import datetime
+          import json
+
+          report_start_date = "${{ inputs.last-modified-date }}"
+          products = [
+              product.strip()
+              for product in "${{ inputs.products }}".split(",")
+              if product
+          ]
+          payload = {
+              **(dict(report_start_date=report_start_date) if report_start_date else {}),
+              **(dict(product_prefixes=products) if products else {}),
+          }
+
+          with open("${{ env.GITHUB_ENV }}", "a") as f:
+              f.write(f"PAYLOAD={json.dumps(payload)}\n")
+
+      - name: Invoke report generator
+        run: |
+          aws lambda invoke \
+              --function-name ${{ inputs.lambda-function-name }} \
+              --invocation-type ${{ inputs.dry-run && 'DryRun' || 'Event' }} \
+              --cli-binary-format raw-in-base64-out \
+              --payload '${{ env.PAYLOAD }}' \
+              --output json \
+              lambda-event-output.json

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -16,12 +16,6 @@ on:
           L30, L30_VI, S30, S30_VI)
         required: false
         type: string
-      lambda-function-name:
-        description: Name or ARN of the report-generator Lambda function
-        required: false
-        type: string
-        # TODO Find reliable means of looking this up in a job step
-        default: hls-lpdaac-reconciliation-InventoryReportHandler89-HlYwwIOfV3yw
       dry-run:
         description: >
           If true, perform a "dry run" invocation of the report generator Lambda
@@ -71,10 +65,25 @@ jobs:
           with open("${{ env.GITHUB_ENV }}", "a") as f:
               f.write(f"PAYLOAD={json.dumps(payload)}\n")
 
-      - name: Invoke report generator
+      - name: Determine name of report generator Lambda function
+        run: |
+          # The value of stack_name must match the construct_id argument passed
+          # to the HlsLpdaacReconciliationStack constructor in cdk/app.py.
+          stack_name=${{ env.HLS_LPDAAC_STACK }}-lpdaac-reconciliation
+
+          function_name=$(
+              aws cloudformation describe-stacks \
+                  --stack-name ${stack_name} \
+                  --query "Stacks[0].Outputs[?OutputKey == 'InventoryReportGenerator'].OutputValue" \
+                  --output text
+          )
+
+          echo FUNCTION_NAME=${function_name} >> $GITHUB_ENV
+
+      - name: Invoke report generator Lambda function
         run: |
           aws lambda invoke \
-              --function-name ${{ inputs.lambda-function-name }} \
+              --function-name ${{ env.FUNCTION_NAME }} \
               --invocation-type ${{ inputs.dry-run && 'DryRun' || 'Event' }} \
               --cli-binary-format raw-in-base64-out \
               --payload '${{ env.PAYLOAD }}' \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: HLS LPDAAC Reconciliation Report
+name: Test and Deploy Stack
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HLS LPDAAC Reconciliation
 
+## Development
+
 HLS LPDAAC Reconciliation is an AWS CloudFormation stack deployed via the AWS
 CDK to the HLS account in MCP.  As such, deployment occurs only via GitHub
 Workflows.
@@ -93,3 +95,31 @@ automatically use your public GitHub email address as the value of the
 `HLS_LPDAAC_NOTIFICATION_EMAIL_ADDRESS` environment variable, so there is no
 need to set this variable in the GitHub repository's `dev` environment.  It is
 set only in the `prod` environment.
+
+## Manually Generating an Inventory Report
+
+Although inventory reports are generated automatically, there may be a need to
+manually generate a report for a specific date and/or specific products.
+
+This can be done via the command line via the
+[GitHub CLI](https://cli.github.com/), which you must install, if you haven't
+already done so, as follows:
+
+```plain
+gh workflow run inventory.yml [-f last-modified-date=LAST_MOD_DATE] [-f products=PRODUCTS] [-f dry-run=DRY_RUN]
+```
+
+where:
+
+- `LAST_MOD_DATE` selects all files with the specified last modified date for
+  inclusion in the generated report(s).  It may be formatted as either
+  `YYYY-MM-DD` or as `YYYYDDD` (no dash), where `DDD` is the day of year.  If
+  not specified, this defaults to 2 days prior to the current date.
+- `PRODUCTS` is a comma-separated list of products to generate reports for,
+  defaulting to all products (L30,L30_VI,S30,S30_VI), if not specified.
+- `DRY_RUN` must be either `true` or `false`.  If `true`, the Lambda function
+  that generates reports will be invoked with an invocation type of `DryRun`
+  rather than `Event`, meaning that the command will be visible in the GitHub
+  workflow logs, but the function will not be executed.  If not specified, this
+  defaults to `false`, meaning that the function will be invoked with an
+  invocation type of `Event`.

--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -1,6 +1,6 @@
 from typing import Any, cast
 
-from aws_cdk import Duration, RemovalPolicy, Stack
+from aws_cdk import CfnOutput, Duration, RemovalPolicy, Stack
 from aws_cdk import aws_glue as glue
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_lambda as lambda_
@@ -171,6 +171,12 @@ class HlsLpdaacReconciliationStack(Stack):
         s3.Bucket.from_bucket_name(
             self, "LpdaacReconciliationReports", lpdaac_reconciliation_reports_bucket
         ).grant_read(lpdaac_response_lambda)
+
+        CfnOutput(
+            self,
+            "InventoryReportGenerator",
+            value=inventory_report_lambda.function_name,
+        )
 
     def make_inventory_table(self, *, location: str) -> glue.CfnTable:
         from aws_cdk.aws_glue import CfnTable

--- a/src/hls_lpdaac_reconciliation/generate_report/__init__.py
+++ b/src/hls_lpdaac_reconciliation/generate_report/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import csv
+import datetime as dt
 from collections.abc import Iterable, Iterator, Sequence
 from pathlib import Path
 
@@ -18,6 +19,23 @@ REPORT_FIELD_NAMES: Sequence[str] = (
     "last_modified",
     "checksum",
 )
+
+
+def parse_date(date_str: str) -> dt.date:
+    """Parse string formatted as an ISO date or as year+doy (%Y%j) into a date.
+
+    Examples
+    --------
+    >>> parse_date("2025-07-29")
+    datetime.date(2025, 7, 29)
+    >>> parse_date("2025161")
+    datetime.date(2025, 6, 10)
+    """
+
+    try:
+        return dt.datetime.fromisoformat(date_str).date()
+    except ValueError:
+        return dt.datetime.strptime(date_str, "%Y%j").date()
 
 
 def row_values(row: RowTypeDef) -> Sequence[str]:

--- a/src/hls_lpdaac_reconciliation/generate_report/index.py
+++ b/src/hls_lpdaac_reconciliation/generate_report/index.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from mypy_boto3_athena.type_defs import RowTypeDef
     from mypy_boto3_s3.client import S3Client
 
-from hls_lpdaac_reconciliation.generate_report import as_records, to_csv
+from hls_lpdaac_reconciliation.generate_report import as_records, parse_date, to_csv
 
 _DEFAULT_PRODUCT_PREFIXES: Final[Sequence[str]] = ("S30", "L30", "S30_VI", "L30_VI")
 
@@ -243,10 +243,10 @@ def handler(event: dict[str, Any], _context: object) -> None:
     - `HLS_PRODUCT_VERSION` (HLS version, excluding the `v` prefix -- e.g., "2.0")
     """
     report_start_date = (
-        dt.datetime.fromisoformat(report_start_date_str)
+        parse_date(report_start_date_str)
         if (report_start_date_str := event.get("report_start_date"))
-        else dt.datetime.now() - dt.timedelta(days=2)
-    ).date()
+        else (dt.datetime.now() - dt.timedelta(days=2)).date()
+    )
     report_end_date = report_start_date + dt.timedelta(days=1)
     inventory_table_name = os.environ["INVENTORY_TABLE_NAME"]
     query_output_prefix = os.environ["QUERY_OUTPUT_PREFIX"]

--- a/tests/unit/test_generate_report.txt
+++ b/tests/unit/test_generate_report.txt
@@ -1,3 +1,12 @@
+Test `parse_date`:
+
+    >>> from hls_lpdaac_reconciliation.generate_report import parse_date
+
+    >>> parse_date("2025-07-29")
+    datetime.date(2025, 7, 29)
+    >>> parse_date("2025161")
+    datetime.date(2025, 6, 10)
+
 Test `row_values`:
 
     >>> from hls_lpdaac_reconciliation.generate_report import row_values


### PR DESCRIPTION
This allows us to manually trigger inventory report generation (i.e., our reports that we generate from the AWS daily inventory reports) for a specific date and list of products. Further, it allows us to do so via the GitHub CLI, so there is no need to log into MCP to run the Lambda function manually, either via the AWS console or locally via the AWS CLI.

We can then run "backfill" reports for all days from the date that we first started producing VI files up to the date that our reports started to include VI files.