### PR TITLE
Fix manual report workflow

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -50,6 +50,7 @@ jobs:
           from datetime import datetime as dt
           import datetime
           import json
+          import os
 
           report_start_date = "${{ inputs.last-modified-date }}"
           products = [
@@ -62,8 +63,8 @@ jobs:
               **(dict(product_prefixes=products) if products else {}),
           }
 
-          with open("${{ env.GITHUB_ENV }}", "a") as f:
-              f.write(f"PAYLOAD={json.dumps(payload)}\n")
+          with open(os.environ["GITHUB_ENV"], "a") as env_file:
+              print(f"PAYLOAD={json.dumps(payload)}", file=env_file)
 
       - name: Determine name of report generator Lambda function
         run: |


### PR DESCRIPTION
It appears that `${{ env.GITHUB_ENV }}` is not substituted into a github workflow step that uses python as the shell, so seeing if we can use `os.environ["GITHUB_ENV"]` to get the value instead.