### PR TITLE
feat: log replayed granule ids

### DIFF
--- a/src/hls_lpdaac_reconciliation/response/index.py
+++ b/src/hls_lpdaac_reconciliation/response/index.py
@@ -81,7 +81,7 @@ def handler(
 
     if subject and "Ok" in subject:
         # When the subject contains (ends with) "Ok", the message itself
-        # indicates that there are no discrepencies, so there's nothing to do.
+        # indicates that there are no discrepancies, so there's nothing to do.
         # Example: "[External] Rec-Report HLS lp-prod HLS_reconcile_2024240_2.0.rpt Ok"
         return {}
 

--- a/src/hls_lpdaac_reconciliation/response/index.py
+++ b/src/hls_lpdaac_reconciliation/response/index.py
@@ -263,6 +263,7 @@ def process_granule(*, granule_id: str, data_bucket_name: str) -> Status:
             CopySource=f"{data_bucket_name}/{key}",
             MetadataDirective="REPLACE",
         )
+        print(f"Re-touched granule_id={granule_id}")
         return Status.TRIGGERED
 
     return Status.MISSING

--- a/tests/integration/test_generate_report.py
+++ b/tests/integration/test_generate_report.py
@@ -161,9 +161,8 @@ def report_uris(
         for message in consume_messages(sqs, lpdaac_request_queue_url)
     )
 
-    # We have 4 products (L30, L30_VI, S30, S30_VI), but should only expect 1
-    # message in the queue corresponding to the `inventory_df`
-    assert len(uris) == 1
+    # We expect 1 for each of our 4 products (L30, L30_VI, S30, S30_VI)
+    assert len(uris) == 4
 
     return uris
 

--- a/tests/integration/test_generate_report.py
+++ b/tests/integration/test_generate_report.py
@@ -161,8 +161,9 @@ def report_uris(
         for message in consume_messages(sqs, lpdaac_request_queue_url)
     )
 
-    # We expect 1 for each of our 4 products (L30, L30_VI, S30, S30_VI)
-    assert len(uris) == 4
+    # We have 4 products (L30, L30_VI, S30, S30_VI), but should only expect 1
+    # message in the queue corresponding to the `inventory_df`
+    assert len(uris) == 1
 
     return uris
 

--- a/tests/integration/test_generate_report.py
+++ b/tests/integration/test_generate_report.py
@@ -40,7 +40,8 @@ def consume_messages(sqs: SQSClient, queue_url: str) -> Iterator[str]:
         for message in sqs.receive_message(
             QueueUrl=queue_url,
             MaxNumberOfMessages=10,
-            WaitTimeSeconds=time_remaining.seconds,
+            # WaitTimeSeconds must be between 0 and 20
+            WaitTimeSeconds=min(time_remaining.seconds, 20),
         ).get("Messages", []):
             receipt = message["ReceiptHandle"]
             sqs.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt)

--- a/tests/integration/test_generate_report.py
+++ b/tests/integration/test_generate_report.py
@@ -30,7 +30,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
 
 
 def consume_messages(sqs: SQSClient, queue_url: str) -> Iterator[str]:
-    timeout = dt.datetime.now() + dt.timedelta(seconds=20)
+    timeout = dt.datetime.now() + dt.timedelta(seconds=30)
 
     # Since we expect to generate multiple report files, each triggering a
     # distinct message, the first call to sqs.receive_message might return a


### PR DESCRIPTION
## Description

This PR adds a print statement for granules we restage by re-touching. This is intended to help debug an ongoing issue where LPDAAC is seeing duplicate ingest requests for the same granule. 

Right now it's a little difficult to trace in our logs what the reconciliation process is triggering. The `hls-lpdaac` process is the final source of truth for forwarding the message back to LPDAAC, but my thought here was to be able to better identify the cause of the messages in the `hls-lpdaac-forward-*` Lambda (some granule production process? or a re-touch via reconciliation?)