### PR TITLE
fix: org secret added w/ newline

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -19,7 +19,7 @@ runs:
   using: composite
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v5
       with:
         aws-region: "${{ inputs.aws_region || 'us-west-2' }}"
         role-to-assume: "${{ inputs.aws_role_to_assume_arn }}"

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -12,10 +12,6 @@ inputs:
     required: true
   stack_name:
     description: Name of the stack to deploy (intended only for uniquely naming integration test stacks)
-  vars_json:
-    description: Environment variables as a JSON object
-  secrets_json:
-    description: Secrets as a JSON object
   command:
     description: Bash command to deploy stack
 
@@ -28,20 +24,6 @@ runs:
         aws-region: "${{ inputs.aws_region || 'us-west-2' }}"
         role-to-assume: "${{ inputs.aws_role_to_assume_arn }}"
         role-session-name: "${{ inputs.aws_role_session_name }}"
-
-    - name: Convert secrets to environment variables
-      shell: bash
-      run: |
-        while read -rd $'' line; do
-          echo "$line" >> $GITHUB_ENV
-        done < <(jq -r <<<'${{ inputs.secrets_json }}' 'to_entries|map("\(.key)=\(.value)\u0000")[]')
-
-    - name: Convert vars to environment variables
-      shell: bash
-      run: |
-        while read -rd $'' line; do
-          echo "$line" >> $GITHUB_ENV
-        done < <(jq -r <<<'${{ inputs.vars_json }}' 'to_entries|map("\(.key)=\(.value)\u0000")[]')
 
     - name: Get user's email address
       if: ${{ ! env.HLS_LPDAAC_NOTIFICATION_EMAIL_ADDRESS }}

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -15,7 +15,7 @@ runs:
         cache-dependency-glob: uv.lock
 
     - name: Install Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version-file: pyproject.toml
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,26 @@ jobs:
         run: |
           echo "HLS_LPDAAC_STACK_OVERRIDE=test-$(echo ${{ github.sha }} | cut -c 1-7)" >> $GITHUB_ENV
 
+      - name: Convert secrets and vars to environment variables
+        shell: python
+        run: |
+          import os
+
+          secrets_and_vars = {
+              **${{ toJson(secrets) }},
+              **${{ toJson(vars) }},
+          }
+
+          with open(os.environ["GITHUB_ENV"], "a") as env_file:
+              for name, value in secrets_and_vars.items():
+                  # If the value contains a newline, use the delimiter syntax
+                  # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#multiline-strings
+                  if "\n" in value:
+                      print(f"{name}<<EOF\n{value}\nEOF", file=env_file)
+                  else:
+                      # Standard format for single lines
+                      print(f"{name}={value}", file=env_file)
+
       - name: Deploy integration tests stack
         uses: ./.github/actions/deploy
         with:
@@ -81,8 +101,6 @@ jobs:
           aws_role_to_assume_arn: "${{ vars.AWS_ROLE_TO_ASSUME_ARN }}"
           aws_role_session_name: "${{ github.actor }}"
           stack_name: "${{ env.HLS_LPDAAC_STACK_OVERRIDE }}"
-          vars_json: "${{ toJson(vars) }}"
-          secrets_json: "${{ toJson(secrets) }}"
           command: make deploy-it
 
       - name: Run integration tests
@@ -103,12 +121,30 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v5
 
+      - name: Convert secrets and vars to environment variables
+        shell: python
+        run: |
+          import os
+
+          secrets_and_vars = {
+              **${{ toJson(secrets) }},
+              **${{ toJson(vars) }},
+          }
+
+          with open(os.environ["GITHUB_ENV"], "a") as env_file:
+              for name, value in secrets_and_vars.items():
+                  # If the value contains a newline, use the delimiter syntax
+                  # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#multiline-strings
+                  if "\n" in value:
+                      print(f"{name}<<EOF\n{value}\nEOF", file=env_file)
+                  else:
+                      # Standard format for single lines
+                      print(f"{name}={value}", file=env_file)
+
       - name: Deploy production stack
         uses: ./.github/actions/deploy
         with:
           aws_region: "${{ vars.AWS_DEFAULT_REGION }}"
           aws_role_to_assume_arn: "${{ vars.AWS_ROLE_TO_ASSUME_ARN }}"
           aws_role_session_name: "${{ github.actor }}"
-          vars_json: "${{ toJson(vars) }}"
-          secrets_json: "${{ toJson(secrets) }}"
           command: make deploy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
     environment: dev
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Get commit short SHA
         run: |
@@ -119,7 +119,7 @@ jobs:
     environment: prod
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Convert secrets and vars to environment variables
         shell: python

--- a/tests/integration/test_generate_report.py
+++ b/tests/integration/test_generate_report.py
@@ -40,7 +40,8 @@ def consume_messages(sqs: SQSClient, queue_url: str) -> Iterator[str]:
         for message in sqs.receive_message(
             QueueUrl=queue_url,
             MaxNumberOfMessages=10,
-            WaitTimeSeconds=time_remaining.seconds,
+            # WaitTimeSeconds must be between 0 and 20
+            WaitTimeSeconds=min(time_remaining.seconds, 20),
         ).get("Messages", []):
             receipt = message["ReceiptHandle"]
             sqs.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt)

--- a/tests/integration/test_generate_report.py
+++ b/tests/integration/test_generate_report.py
@@ -30,7 +30,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
 
 
 def consume_messages(sqs: SQSClient, queue_url: str) -> Iterator[str]:
-    timeout = dt.datetime.now() + dt.timedelta(seconds=20)
+    timeout = dt.datetime.now() + dt.timedelta(seconds=30)
 
     # Since we expect to generate multiple report files, each triggering a
     # distinct message, the first call to sqs.receive_message might return a


### PR DESCRIPTION
## What I am changing

Fixes an issue dumping secrets now that there's an org level secret with a newline in it. Figured it's better to make sure we don't break if this happens versus removing the org secret, since someone can always re-add something like this.

Ref: https://github.com/NASA-IMPACT/csdap-orders/issues/624#issuecomment-3790022038

## How I did it

- Escape newline in org level secret
- Bump `checkout`, `setup-python`, and `configure-aws-credentials` action versions
- Include fix for queue polling wait time from https://github.com/NASA-IMPACT/hls-lpdaac-reconciliation/pull/33

## How you can test it

deploy workflow